### PR TITLE
fix: Add Python 3.12 compatibility by including setuptools>=68

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # YouTube Channel Auto-List (US/English Edition)
 
-[![Python Version](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/)
+[![Python Version](https://img.shields.io/badge/python-3.11%2B%20|%203.12-blue)](https://www.python.org/)
 [![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![GitHub Actions](https://img.shields.io/badge/CI-GitHub%20Actions-2088FF?logo=github-actions)](https://github.com/Jun2664/yt-channel-autolist/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -38,10 +38,12 @@ YouTube Channel Auto-List is a Python tool that automatically discovers, analyze
 
 ### Prerequisites
 
-- Python 3.11+
+- Python 3.11+ (Python 3.12 is supported with setuptools>=68)
 - Chrome/Chromium browser
 - pip or Poetry for package management
 - Google Cloud account (for Sheets export only)
+
+**Note for Python 3.12 users**: Python 3.12 removed the `distutils` module from the standard library. This project includes `setuptools>=68` in requirements.txt which provides a compatibility layer for packages that still depend on `distutils` (like undetected-chromedriver 3.5.4).
 
 ### 1. Clone Repository
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ beautifulsoup4==4.12.2
 undetected-chromedriver==3.5.4
 langdetect==1.0.9
 fake-useragent==1.4.0
+setuptools>=68.0.0  # Required for Python 3.12 compatibility (provides distutils)


### PR DESCRIPTION
## Summary

This PR fixes the `ModuleNotFoundError: distutils` error that occurs when running the project with Python 3.12.

## Changes

- Added `setuptools>=68.0.0` to requirements.txt to provide distutils compatibility layer
- Updated README.md to document Python 3.12 support and explain the distutils removal
- Updated Python version badge to explicitly include 3.12

## Technical Details

Python 3.12 removed the `distutils` module from the standard library as per PEP 632. The `undetected-chromedriver` package (version 3.5.4) still depends on `distutils.version.LooseVersion`. By including `setuptools>=68`, we get a vendored copy of distutils that maintains backward compatibility.

This is a temporary solution until undetected-chromedriver updates to use `packaging.version` instead of `distutils`.

Fixes #16

🤖 Generated with [Claude Code](https://claude.ai/code)