### PR TITLE
fix: add missing google-api-python-client dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 google-auth==2.23.4
 google-auth-oauthlib==1.1.0
 google-auth-httplib2==0.1.1
+google-api-python-client>=2.123.0
 gspread==5.12.0
 python-dotenv==1.0.0
 nltk==3.8.1


### PR DESCRIPTION
Fixes #18 - Missing dependency: google-api-python-client

This PR adds the missing `google-api-python-client` package to `requirements.txt` which provides the `googleapiclient` module used by the YouTube scraper.

## Changes
- Added `google-api-python-client>=2.123.0` to requirements.txt

## Testing
After installing dependencies with `pip install -r requirements.txt`, the import error should be resolved.

Generated with [Claude Code](https://claude.ai/code)