### PR TITLE
fix: update Chrome driver dependencies and configuration

### DIFF
--- a/config.py
+++ b/config.py
@@ -58,5 +58,6 @@ class Config:
             'headless': bool(os.getenv('SCRAPER_HEADLESS', 'true').lower() == 'true'),
             'user_agent_rotation': bool(os.getenv('USER_AGENT_ROTATION', 'true').lower() == 'true'),
             'max_retries': int(os.getenv('MAX_RETRIES', 3)),
-            'timeout': int(os.getenv('PAGE_TIMEOUT', 30))
+            'timeout': int(os.getenv('PAGE_TIMEOUT', 30)),
+            'chrome_version': os.getenv('CHROME_VERSION', None)
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ gspread==5.12.0
 python-dotenv==1.0.0
 nltk==3.8.1
 requests==2.31.0
-selenium==4.15.2
+selenium>=4.21.0
 beautifulsoup4==4.12.2
-undetected-chromedriver==3.5.4
+undetected-chromedriver>=3.6.1
 langdetect==1.0.9
 fake-useragent==1.4.0
 setuptools>=68.0.0  # Required for Python 3.12 compatibility (provides distutils)

--- a/web_scraper.py
+++ b/web_scraper.py
@@ -53,7 +53,17 @@ class YouTubeScraper:
         options.add_experimental_option('prefs', {'intl.accept_languages': 'en-US,en'})
         
         if self.scraper_config['use_undetected_driver']:
-            driver = uc.Chrome(options=options)
+            # Try to use Chrome with explicit version if available
+            try:
+                chrome_version = self.scraper_config.get('chrome_version')
+                if chrome_version:
+                    driver = uc.Chrome(options=options, version_main=int(chrome_version))
+                else:
+                    driver = uc.Chrome(options=options)
+            except Exception as e:
+                logger.warning(f"Failed to initialize undetected Chrome driver: {e}")
+                # Fallback to regular Chrome driver
+                driver = webdriver.Chrome(options=options)
         else:
             driver = webdriver.Chrome(options=options)
             


### PR DESCRIPTION
## Summary

This PR fixes the "invalid argument: unrecognized chrome option: prefs" error by updating Chrome driver dependencies and improving error handling.

## Changes

- Update selenium to >=4.21.0 and undetected-chromedriver to >=3.6.1
- Add error handling with fallback to regular Chrome driver
- Make Chrome version configurable via CHROME_VERSION environment variable
- Keep correct add_experimental_option('prefs', ...) syntax

Fixes #20

🤖 Generated with [Claude Code](https://claude.ai/code)