### PR TITLE
fix: update undetected-chromedriver to 3.5.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ nltk==3.8.1
 requests==2.31.0
 selenium>=4.21.0
 beautifulsoup4==4.12.2
-undetected-chromedriver>=3.6.1
+undetected-chromedriver==3.5.5
 langdetect==1.0.9
 fake-useragent==1.4.0
 setuptools>=68.0.0  # Required for Python 3.12 compatibility (provides distutils)


### PR DESCRIPTION
Replace invalid version constraint >=3.6.1 with ==3.5.5 (latest PyPI release)
to fix pip install error.

Fixes #22

Generated with [Claude Code](https://claude.ai/code)