### PR TITLE
fix: ChromeDriver compatibility issue with prefs option

### DIFF
--- a/web_scraper.py
+++ b/web_scraper.py
@@ -50,16 +50,17 @@ class YouTubeScraper:
             options.add_argument(f'user-agent={user_agent}')
             
         # Accept-Language header for US English
-        options.add_experimental_option('prefs', {'intl.accept_languages': 'en-US,en'})
+        # Commented out due to undetected-chromedriver v3 compatibility issue
+        # options.add_experimental_option('prefs', {'intl.accept_languages': 'en-US,en'})
         
         if self.scraper_config['use_undetected_driver']:
             # Try to use Chrome with explicit version if available
             try:
                 chrome_version = self.scraper_config.get('chrome_version')
                 if chrome_version:
-                    driver = uc.Chrome(options=options, version_main=int(chrome_version))
+                    driver = uc.Chrome(options=options, version_main=int(chrome_version), use_subprocess=True)
                 else:
-                    driver = uc.Chrome(options=options)
+                    driver = uc.Chrome(options=options, use_subprocess=True)
             except Exception as e:
                 logger.warning(f"Failed to initialize undetected Chrome driver: {e}")
                 # Fallback to regular Chrome driver


### PR DESCRIPTION
## Summary

This PR fixes the ChromeDriver startup error "unrecognized chrome option: prefs" that occurs when running `python main.py`.

## Changes

- Commented out the `prefs` option in `web_scraper.py` that was causing compatibility issues with undetected-chromedriver v3.5.5
- Added `use_subprocess=True` parameter to `uc.Chrome()` initialization for better compatibility

## Testing

The changes follow the recommended fix from issue #24 and should allow ChromeDriver to start successfully without the "unrecognized chrome option" error.

Fixes #24

Generated with [Claude Code](https://claude.ai/code)